### PR TITLE
Corrected link to live version of RSR Observing Summary

### DIFF
--- a/bin/rsr_readme
+++ b/bin/rsr_readme
@@ -13,7 +13,7 @@ fi
 
 url1="http://lmtgtm.org/telescope/instrumentation/instruments/rsr/"
 url2="https://www.lmtobservatory.org/help/user/calculation_rsr"
-url3="http://lmtgtm.org/wp-content/uploads/2022/09/RSR_v2p0_reduced.pdf"
+url3="http://lmtgtm.org/rsr/"
 
 #            required:   2 arguments
 obsnum=$1


### PR DESCRIPTION
Current url3 value sends to a location with a legacy document. The new value show the actual web page with the "live document"